### PR TITLE
fix(session): correct vulnerability deduplication logic

### DIFF
--- a/airecon/proxy/agent/session.py
+++ b/airecon/proxy/agent/session.py
@@ -88,16 +88,12 @@ def _is_duplicate_vulnerability(
         existing_finding = existing.get("finding", "")
         existing_target = existing.get("target", "")
 
-        # If both findings specify a non-empty target and they differ, they are
-        # findings on different endpoints and must NOT be merged regardless of
-        # how similar the description text is.
-        if new_target and existing_target and new_target != existing_target:
-            continue
-
-        # Check finding similarity
+        # Check finding similarity — _calculate_similarity already returns 0.0
+        # when the two findings mention different URL parameters, preventing
+        # false deduplication of findings on different parameters.
         finding_sim = _calculate_similarity(new_finding, existing_finding)
 
-        # Target similarity only applies when one side has no target
+        # Check target similarity (if both have targets)
         target_sim = 1.0 if new_target == existing_target else 0.0
 
         # Combined similarity


### PR DESCRIPTION
## Summary

- Reverts an incorrect guard added in the previous #12 fix that caused `_is_duplicate_vulnerability()` to return `False` whenever the two findings had different non-empty targets.
- The old guard incorrectly prevented same-vuln findings on different subdomains (e.g. `example.com` vs `api.example.com`) from being deduplicated — which breaks `test_is_duplicate_vulnerability`.
- The actual fix for issue #12 (findings on **different parameters** must not merge) is correctly handled by `_calculate_similarity()`, which already returns `0.0` when the two strings reference different URL parameters via regex extraction.

## Root Cause

`fix: resolve issues #6 #7 #8 #11 #14` (commit `a1c42fb`) and the subsequent commit for #12 added:
```python
if new_target and existing_target and new_target != existing_target:
    continue
```
This skips deduplication for **any** different target, including subdomains — but the intended behaviour is to keep deduplication across subdomains (same vuln type = same finding), while only rejecting duplicates when the **parameter** targeted differs.

## Test plan

- [x] `tests/proxy/agent/test_session.py::test_is_duplicate_vulnerability` now passes
- [x] All 71 unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)