### PR TITLE
fix(review): address all 5 code review findings from PR #36

### DIFF
--- a/airecon/proxy/agent/formatters.py
+++ b/airecon/proxy/agent/formatters.py
@@ -88,11 +88,20 @@ _PORT_OPEN_RE = re.compile(
     r"|\[(\d{2,5})\]",                       # httpx: [80]
 )
 
+# Short tech names (< 5 chars: "go", "php", "lua", "java") need non-alphanumeric
+# boundaries to avoid false positives — e.g. "go" matching "google" or "django".
+# Longer names are specific enough for plain substring matching.
+_TECH_HINT_RE: dict[str, re.Pattern[str]] = {
+    tech: re.compile(rf"(?<![a-z0-9]){re.escape(tech)}(?![a-z0-9])")
+    for tech in _TECH_HINTS
+    if len(tech) < 5
+}
+
 
 def _extract_security_hints(output: str) -> list[str]:
     """Scan tool output for open ports and tech stack, return actionable hints."""
     hints: list[str] = []
-    seen: set[Any] = set()
+    seen: set[int | str] = set()
     out_lower = output.lower()
 
     # Port-based hints
@@ -105,9 +114,13 @@ def _extract_security_hints(output: str) -> list[str]:
             hints.append(f"  PORT {port}: {_PORT_HINTS[port]}")
             seen.add(port)
 
-    # Technology-based hints
+    # Technology-based hints — use word-boundary regex for short names
     for tech, hint in _TECH_HINTS.items():
-        if tech in out_lower and tech not in seen:
+        if tech in seen:
+            continue
+        pattern = _TECH_HINT_RE.get(tech)
+        found = bool(pattern.search(out_lower)) if pattern else (tech in out_lower)
+        if found:
             hints.append(f"  TECH {tech.upper()}: {hint}")
             seen.add(tech)
 

--- a/airecon/proxy/agent/output_parser.py
+++ b/airecon/proxy/agent/output_parser.py
@@ -30,7 +30,10 @@ class ParsedOutput:
     technologies: dict[str, str] = field(default_factory=dict)
 
 
-# Maximum items to include in parsed output for LLM context
+# Maximum items to include in parsed output for LLM context.
+# Raised from 25 → 100 to give the LLM broader coverage of large scans
+# (e.g. 80+ open ports from nmap, 100+ endpoints from ffuf).
+# Monitor prompt size if slow responses or context-limit errors appear.
 MAX_ITEMS = 100
 MAX_RAW_FALLBACK = 3000
 

--- a/airecon/proxy/agent/pipeline.py
+++ b/airecon/proxy/agent/pipeline.py
@@ -255,7 +255,18 @@ class PipelineEngine:
                 met.append("urls_collected")
             if getattr(session, "technologies", {}):
                 met.append("technologies_identified")
-            if getattr(session, "injection_points", []):
+            # Require at least 3 distinct injection points OR at least one
+            # point with a security-relevant type (not just tracking params
+            # like utm_source that inflate the count without adding value).
+            _MEANINGFUL_TYPES = frozenset({
+                "IDOR", "SSRF", "PATH_TRAVERSAL", "SQLi",
+                "XSS", "AUTH", "BUSINESS_LOGIC", "RCE",
+            })
+            _ips = getattr(session, "injection_points", [])
+            _has_meaningful = any(
+                p.get("type_hint") in _MEANINGFUL_TYPES for p in _ips
+            )
+            if len(_ips) >= 3 or _has_meaningful:
                 met.append("injection_points_found")
 
         elif phase == PipelinePhase.EXPLOIT:

--- a/airecon/proxy/agent/session.py
+++ b/airecon/proxy/agent/session.py
@@ -108,17 +108,19 @@ def _extract_injection_points(url: str) -> list[dict[str, Any]]:
                 "type_hint": _guess_injection_type(param, value),
             })
 
-        # Path segments that look like IDs (numeric or UUID)
+        # Path segments that look like IDs (numeric or UUID).
+        # Use the full URL so the LLM knows the complete endpoint context
+        # (e.g. /api/users/123/orders — the ID belongs to 'users', and
+        # /orders shows what sub-resource is being accessed).
         path_parts = [x for x in p.path.strip("/").split("/") if x]
         for i, seg in enumerate(path_parts):
             if re.match(r"^\d{1,10}$", seg) or _UUID_RE.match(seg):
-                path_base = (
-                    f"{p.scheme}://{p.netloc}/"
-                    + "/".join(path_parts[: i + 1])
-                )
+                # Label: parent-resource/ID so the LLM knows which resource owns this ID
+                parent = path_parts[i - 1] if i > 0 else ""
+                param_label = f"path/{parent}/{seg}" if parent else f"path/{seg}"
                 points.append({
-                    "url": path_base,
-                    "parameter": f"path_segment[{i}]",
+                    "url": base,  # full URL preserves sub-resource context
+                    "parameter": param_label,
                     "method": "GET",
                     "value_sample": seg,
                     "type_hint": "IDOR",

--- a/tests/proxy/agent/test_injection_extraction.py
+++ b/tests/proxy/agent/test_injection_extraction.py
@@ -1,0 +1,237 @@
+"""Tests for injection point extraction helpers in session.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from airecon.proxy.agent.session import (
+    _extract_injection_points,
+    _guess_injection_type,
+    _merge_injection_points,
+)
+from airecon.proxy.agent.formatters import _load_port_hints, _load_tech_hints
+
+
+# ---------------------------------------------------------------------------
+# _guess_injection_type
+# ---------------------------------------------------------------------------
+
+class TestGuessInjectionType:
+    def test_canonical_map_id(self):
+        # "id" is a canonical IDOR param in fuzzer_data.json PARAM_TYPE_MAP
+        result = _guess_injection_type("id", "42")
+        assert result in ("IDOR", "INJECT")  # depends on fuzzer_data presence
+
+    def test_suffix_id(self):
+        assert _guess_injection_type("user_id", "") == "IDOR"
+        assert _guess_injection_type("product_id", "") == "IDOR"
+
+    def test_suffix_id_end(self):
+        assert _guess_injection_type("userid", "") == "IDOR"
+
+    def test_numeric_value_fallback(self):
+        # Any param with numeric value → IDOR
+        assert _guess_injection_type("ref", "12345") == "IDOR"
+
+    def test_large_numeric_value_not_matched(self):
+        # >10 digits should NOT trigger numeric IDOR heuristic.
+        # Use a param name unlikely to be in the canonical map.
+        result = _guess_injection_type("zzz_unknown_param_xyz", "12345678901")
+        # 11-digit value exceeds the ^\d{1,10}$ pattern — should NOT be IDOR from value
+        assert result == "INJECT"
+
+    def test_camelcase_normalisation(self):
+        # "userId" → "user_id" which matches suffix heuristic
+        result = _guess_injection_type("userId", "")
+        assert result == "IDOR"
+
+    def test_default_inject(self):
+        result = _guess_injection_type("q", "")
+        # "q" may be in canonical map as XSS/SQLi or default INJECT
+        assert isinstance(result, str) and len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_injection_points
+# ---------------------------------------------------------------------------
+
+class TestExtractInjectionPoints:
+    def test_query_params_extracted(self):
+        url = "https://example.com/search?q=hello&page=2"
+        points = _extract_injection_points(url)
+        params = {p["parameter"] for p in points}
+        assert "q" in params
+        assert "page" in params
+
+    def test_query_param_method_is_get(self):
+        url = "https://example.com/items?id=5"
+        points = _extract_injection_points(url)
+        assert all(p["method"] == "GET" for p in points)
+
+    def test_query_param_value_sample_truncated(self):
+        url = "https://example.com/search?q=" + "A" * 50
+        points = _extract_injection_points(url)
+        q_point = next(p for p in points if p["parameter"] == "q")
+        assert len(q_point["value_sample"]) <= 30
+
+    def test_numeric_path_segment_detected(self):
+        url = "https://example.com/api/users/123"
+        points = _extract_injection_points(url)
+        assert any("123" in p["parameter"] or "123" == p["value_sample"] for p in points)
+
+    def test_uuid_path_segment_detected(self):
+        uid = "550e8400-e29b-41d4-a716-446655440000"
+        url = f"https://example.com/api/items/{uid}"
+        points = _extract_injection_points(url)
+        assert any(uid in p["value_sample"] for p in points)
+
+    def test_path_segment_type_hint_is_idor(self):
+        url = "https://example.com/users/42"
+        points = _extract_injection_points(url)
+        id_points = [p for p in points if p["value_sample"] == "42"]
+        assert id_points, "Expected numeric path segment point"
+        assert id_points[0]["type_hint"] == "IDOR"
+
+    def test_path_segment_label_includes_parent(self):
+        # /api/users/123 → parameter should be path/users/123
+        url = "https://example.com/api/users/123"
+        points = _extract_injection_points(url)
+        labels = [p["parameter"] for p in points]
+        assert any("users" in lbl and "123" in lbl for lbl in labels)
+
+    def test_full_url_preserved_in_path_point(self):
+        # Fix 1 regression: path segment points must use the full URL, not truncated
+        url = "https://example.com/api/users/123/orders"
+        points = _extract_injection_points(url)
+        id_points = [p for p in points if p["value_sample"] == "123"]
+        assert id_points, "Numeric segment not extracted"
+        # URL must be full path including /orders
+        assert id_points[0]["url"] == "https://example.com/api/users/123/orders"
+
+    def test_no_points_for_static_url(self):
+        url = "https://example.com/about"
+        points = _extract_injection_points(url)
+        assert points == []
+
+    def test_malformed_url_returns_empty(self):
+        points = _extract_injection_points("not-a-url")
+        assert isinstance(points, list)
+
+    def test_empty_string_returns_empty(self):
+        assert _extract_injection_points("") == []
+
+    def test_blank_query_value_included(self):
+        url = "https://example.com/search?q="
+        points = _extract_injection_points(url)
+        params = {p["parameter"] for p in points}
+        assert "q" in params
+
+    def test_non_numeric_path_ignored(self):
+        url = "https://example.com/api/products/slug-name"
+        points = _extract_injection_points(url)
+        # "slug-name" is not numeric or UUID — no path points expected
+        path_points = [p for p in points if p["parameter"].startswith("path/")]
+        assert path_points == []
+
+    def test_url_without_query_or_ids_empty(self):
+        url = "https://example.com/api/v1/health"
+        points = _extract_injection_points(url)
+        assert points == []
+
+
+# ---------------------------------------------------------------------------
+# _merge_injection_points
+# ---------------------------------------------------------------------------
+
+class TestMergeInjectionPoints:
+    def _make_point(self, url: str, param: str, method: str = "GET") -> dict:
+        return {"url": url, "parameter": param, "method": method,
+                "value_sample": "", "type_hint": "INJECT"}
+
+    def test_adds_new_points(self):
+        session = []
+        new = [self._make_point("https://example.com/", "id")]
+        _merge_injection_points(session, new)
+        assert len(session) == 1
+
+    def test_deduplicates_exact(self):
+        session = [self._make_point("https://example.com/", "id")]
+        dup = [self._make_point("https://example.com/", "id")]
+        _merge_injection_points(session, dup)
+        assert len(session) == 1
+
+    def test_different_param_not_deduped(self):
+        session = [self._make_point("https://example.com/", "id")]
+        new = [self._make_point("https://example.com/", "user")]
+        _merge_injection_points(session, new)
+        assert len(session) == 2
+
+    def test_different_method_not_deduped(self):
+        session = [self._make_point("https://example.com/", "id", "GET")]
+        new = [self._make_point("https://example.com/", "id", "POST")]
+        _merge_injection_points(session, new)
+        assert len(session) == 2
+
+    def test_different_url_not_deduped(self):
+        session = [self._make_point("https://example.com/a", "id")]
+        new = [self._make_point("https://example.com/b", "id")]
+        _merge_injection_points(session, new)
+        assert len(session) == 2
+
+    def test_mutates_in_place(self):
+        session: list = []
+        _merge_injection_points(session, [self._make_point("https://x.com/", "p")])
+        assert session  # modified in place
+
+    def test_empty_new_no_change(self):
+        session = [self._make_point("https://example.com/", "id")]
+        _merge_injection_points(session, [])
+        assert len(session) == 1
+
+    def test_multiple_new_batch_deduped(self):
+        session: list = []
+        new = [
+            self._make_point("https://a.com/", "x"),
+            self._make_point("https://a.com/", "x"),  # dup within batch
+            self._make_point("https://a.com/", "y"),
+        ]
+        _merge_injection_points(session, new)
+        assert len(session) == 2  # x (once) + y
+
+
+# ---------------------------------------------------------------------------
+# _load_port_hints / _load_tech_hints (structure validation)
+# ---------------------------------------------------------------------------
+
+class TestLoadHints:
+    def test_port_hints_returns_dict_of_int(self):
+        hints = _load_port_hints()
+        assert isinstance(hints, dict)
+        for key in hints:
+            assert isinstance(key, int), f"Expected int key, got {type(key)}: {key}"
+
+    def test_port_hints_values_are_strings(self):
+        hints = _load_port_hints()
+        for val in hints.values():
+            assert isinstance(val, str)
+
+    def test_tech_hints_returns_dict_of_str(self):
+        hints = _load_tech_hints()
+        assert isinstance(hints, dict)
+        for key in hints:
+            assert isinstance(key, str)
+
+    def test_tech_hints_keys_are_lowercase(self):
+        hints = _load_tech_hints()
+        for key in hints:
+            assert key == key.lower(), f"Key not lowercase: {key}"
+
+    def test_tech_hints_values_are_strings(self):
+        hints = _load_tech_hints()
+        for val in hints.values():
+            assert isinstance(val, str)
+
+    def test_common_ports_present(self):
+        hints = _load_port_hints()
+        # port_correlations.json covers infra ports; SSH (22) and FTP (21) are always present
+        assert 22 in hints or 21 in hints, "Expected at least port 21 or 22 in port hints"


### PR DESCRIPTION
- session.py: path segment injection points now use full URL (preserves sub-resource context, e.g. /api/users/123/orders) + path/parent/ID label
- formatters.py: add _TECH_HINT_RE word-boundary regex for short tech names (<5 chars: go, php, lua) to prevent false positives; fix set[Any] → set[int|str]
- pipeline.py: strengthen injection_points_found criterion — now requires ≥3 distinct points OR at least one meaningful type (IDOR/SSRF/XSS/AUTH/etc.) instead of any single injection point (e.g. ?utm_source)
- output_parser.py: document MAX_ITEMS=100 (raised from 25) with rationale
- tests: add test_injection_extraction.py with 35 tests covering _extract_injection_points, _merge_injection_points, _guess_injection_type, _load_port_hints, _load_tech_hints (all pass)